### PR TITLE
fix: 修复脚本登录失败的问题

### DIFF
--- a/.github/workflows/login.yml
+++ b/.github/workflows/login.yml
@@ -17,9 +17,11 @@ jobs:
       - name: Majsoul login
         run: python login.py ${{ secrets.EMAIL }} ${{ secrets.PASSWD }}
 
-      - name: Upload screenshot
+      - name: Upload screenshots
         uses: actions/upload-artifact@v4
         if: always()
         with:
           name: screenshots
-          path: result_*.png
+          path: |
+            *.png
+            !error_*.png

--- a/.github/workflows/login.yml
+++ b/.github/workflows/login.yml
@@ -16,3 +16,10 @@ jobs:
 
       - name: Majsoul login
         run: python login.py ${{ secrets.EMAIL }} ${{ secrets.PASSWD }}
+
+      - name: Upload screenshot
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: screenshots
+          path: result_*.png

--- a/.github/workflows/login.yml
+++ b/.github/workflows/login.yml
@@ -16,10 +16,3 @@ jobs:
 
       - name: Majsoul login
         run: python login.py ${{ secrets.EMAIL }} ${{ secrets.PASSWD }}
-
-      - name: Upload error screenshot
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: error-screenshots
-          path: "*.png"

--- a/.github/workflows/login.yml
+++ b/.github/workflows/login.yml
@@ -16,3 +16,10 @@ jobs:
 
       - name: Majsoul login
         run: python login.py ${{ secrets.EMAIL }} ${{ secrets.PASSWD }}
+
+      - name: Upload error screenshot
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: error-screenshots
+          path: "*.png"

--- a/login.py
+++ b/login.py
@@ -47,20 +47,20 @@ for i in range(acccounts):
     driver.save_screenshot(f"login_screen_{i+1}.png")
     print('Login screen captured')
 
-    # 4. 输入账号
+    # 4. 输入账号 - 调整坐标
     print('Trying to input email...')
     ActionChains(driver)\
-        .move_to_element_with_offset(screen, 280, -100)\
+        .move_to_element_with_offset(screen, 300, -130)\
         .click()\
         .send_keys(email)\
         .perform()
     sleep(2)
     print('Email input attempted')
 
-    # 5. 输入密码
+    # 5. 输入密码 - 调整坐标
     print('Trying to input password...')
     ActionChains(driver)\
-        .move_to_element_with_offset(screen, 280, -20)\
+        .move_to_element_with_offset(screen, 300, -50)\
         .click()\
         .send_keys(passwd)\
         .perform()
@@ -73,14 +73,28 @@ for i in range(acccounts):
     # 6. 点击登录
     print('Clicking login button...')
     ActionChains(driver)\
-        .move_to_element_with_offset(screen, 280, 60)\
+        .move_to_element_with_offset(screen, 300, 30)\
         .click()\
         .perform()
     print('Login button clicked')
-    sleep(40)
+    sleep(5)
+    
+    # 7. 关闭服务器选择弹窗（如果出现）
+    driver.save_screenshot(f"before_close_{i+1}.png")
+    print('Checking for server selection dialog...')
+    
+    # 点击关闭按钮位置（弹窗右上角）
+    ActionChains(driver)\
+        .move_to_element_with_offset(screen, 300, -200)\
+        .click()\
+        .perform()
+    sleep(2)
+    
+    # 等待进入游戏
+    sleep(35)
     print('Login success')
 
-    # 7. 领取月卡
+    # 8. 领取月卡
     print('Attempting to claim monthly card...')
     sleep(5)
     

--- a/login.py
+++ b/login.py
@@ -14,7 +14,7 @@ for i in range(acccounts):
     passwd = sys.argv[1+i+acccounts]
     print('----------------------------')
 
-    # 1. 浏览器配置（反风控）
+    # 1. 浏览器配置（反风控，GitHub必备）
     options = webdriver.ChromeOptions()
     options.add_argument("--headless=new")
     options.add_argument("--disable-blink-features=AutomationControlled")
@@ -24,60 +24,73 @@ for i in range(acccounts):
     options.add_experimental_option('useAutomationExtension', False)
     
     driver = webdriver.Chrome(options=options)
-    driver.set_window_size(1000, 720)
+    driver.set_window_size(1280, 800)  # 增大窗口尺寸
     driver.get("https://game.maj-soul.net/1/")
     print(f'Account {i+1} loading game...')
-    sleep(10)
+    sleep(15)  # 增加初始加载等待时间
 
     # 2. 等待游戏画布加载
     try:
         screen = WebDriverWait(driver, 20).until(
             EC.presence_of_element_located((By.TAG_NAME, "canvas"))
         )
+        print(f'Canvas found, size: {screen.size}')
     except:
         driver.save_screenshot(f"error_{i+1}.png")
         driver.quit()
         raise
 
-    # 3. 输入账号（修复：正确的Canvas输入方式）
+    # 保存登录界面截图
+    driver.save_screenshot(f"login_screen_{i+1}.png")
+    print('Login screen captured')
+
+    # 3. 输入账号
+    # 尝试不同的坐标位置来定位输入框
+    print('Trying to input email...')
     ActionChains(driver)\
-        .move_to_element_with_offset(screen, 250, -100)\
+        .move_to_element_with_offset(screen, 280, -80)\
         .click()\
         .send_keys(email)\
         .perform()
-    sleep(1)
-    print('Input email successfully')
+    sleep(2)
+    print('Email input attempted')
 
-    # 4. 输入密码（修复：正确的Canvas输入方式）
+    # 4. 输入密码
+    print('Trying to input password...')
     ActionChains(driver)\
-        .move_to_element_with_offset(screen, 250, -50)\
+        .move_to_element_with_offset(screen, 280, -20)\
         .click()\
         .send_keys(passwd)\
         .perform()
-    sleep(1)
-    print('Input password successfully')
+    sleep(2)
+    print('Password input attempted')
+
+    # 保存输入后截图
+    driver.save_screenshot(f"after_input_{i+1}.png")
+    print('Input screen captured')
 
     # 5. 点击登录
+    print('Clicking login button...')
     ActionChains(driver)\
-        .move_to_element_with_offset(screen, 250, 50)\
+        .move_to_element_with_offset(screen, 280, 60)\
         .click()\
         .perform()
-    print('Entering game...')
-    sleep(30)  # 增加等待时间，等待游戏加载完成
+    print('Login button clicked')
+    sleep(30)  # 等待游戏加载完成
     print('Login success')
 
-    # 6. 领取月卡 - 月卡弹窗会在登录后自动显示在中间，直接点击即可
+    # 6. 领取月卡
     print('Attempting to claim monthly card...')
-    sleep(5)  # 等待月卡弹窗出现
+    sleep(5)
     
-    # 第一次点击 - 打开月卡弹窗或点击领取
+    # 第一次点击
     ActionChains(driver)\
         .move_to_element_with_offset(screen, 0, 50)\
         .click()\
         .perform()
     sleep(2)
     
-    # 第二次点击 - 确认领取或关闭弹窗
+    # 第二次点击
     ActionChains(driver)\
         .move_to_element_with_offset(screen, 0, 50)\
         .click()\
@@ -86,7 +99,7 @@ for i in range(acccounts):
     
     print('Monthly card claim attempt completed')
     
-    # 保存截图以便调试
+    # 保存结果截图
     driver.save_screenshot(f"result_{i+1}.png")
     print(f'Screenshot saved as result_{i+1}.png')
     

--- a/login.py
+++ b/login.py
@@ -4,7 +4,6 @@ from time import sleep
 from selenium import webdriver
 from selenium.webdriver import ActionChains
 from selenium.webdriver.common.by import By
-from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 
@@ -40,22 +39,10 @@ for i in range(acccounts):
         driver.quit()
         raise
     
-    # 3. 等待游戏资源加载完成（出现登录界面）
-    max_wait = 90
-    wait_interval = 10
-    waited = 0
-    
+    # 3. 等待游戏资源加载完成
     print('Waiting for game to fully load...')
-    while waited < max_wait:
-        sleep(wait_interval)
-        waited += wait_interval
-        driver.save_screenshot(f"loading_check_{i+1}_{waited}.png")
-        print(f'  Checked at {waited}s')
-        
-        if waited >= 60:
-            break
-    
-    print(f'Waited {waited}s for game load')
+    sleep(60)
+    print('Game load wait completed')
     
     driver.save_screenshot(f"login_screen_{i+1}.png")
     print('Login screen captured')
@@ -63,18 +50,8 @@ for i in range(acccounts):
     # 4. 输入账号
     print('Trying to input email...')
     ActionChains(driver)\
-        .move_to_element_with_offset(screen, 280, -80)\
+        .move_to_element_with_offset(screen, 280, -100)\
         .click()\
-        .perform()
-    sleep(1)
-    # 使用 Keys 来全选
-    ActionChains(driver)\
-        .key_down(Keys.CONTROL)\
-        .send_keys('a')\
-        .key_up(Keys.CONTROL)\
-        .perform()
-    sleep(0.5)
-    ActionChains(driver)\
         .send_keys(email)\
         .perform()
     sleep(2)
@@ -85,15 +62,6 @@ for i in range(acccounts):
     ActionChains(driver)\
         .move_to_element_with_offset(screen, 280, -20)\
         .click()\
-        .perform()
-    sleep(1)
-    ActionChains(driver)\
-        .key_down(Keys.CONTROL)\
-        .send_keys('a')\
-        .key_up(Keys.CONTROL)\
-        .perform()
-    sleep(0.5)
-    ActionChains(driver)\
         .send_keys(passwd)\
         .perform()
     sleep(2)

--- a/login.py
+++ b/login.py
@@ -40,9 +40,9 @@ for i in range(acccounts):
         raise
     
     # 3. 等待游戏资源加载完成（出现登录界面）
-    # 通过多次截图检查来判断是否加载完成
-    max_wait = 60  # 最多等待60秒
-    wait_interval = 5  # 每5秒检查一次
+    # 等待更长时间，直到登录界面完全加载
+    max_wait = 90  # 最多等待90秒
+    wait_interval = 10  # 每10秒检查一次
     waited = 0
     
     print('Waiting for game to fully load...')
@@ -52,9 +52,8 @@ for i in range(acccounts):
         driver.save_screenshot(f"loading_check_{i+1}_{waited}.png")
         print(f'  Checked at {waited}s')
         
-        # 检查是否已经出现登录输入框（通过像素判断）
-        # 这里简化处理：等待足够长时间
-        if waited >= 30:  # 至少等待30秒
+        # 等待60秒后尝试输入
+        if waited >= 60:
             break
     
     print(f'Waited {waited}s for game load')
@@ -63,11 +62,23 @@ for i in range(acccounts):
     driver.save_screenshot(f"login_screen_{i+1}.png")
     print('Login screen captured')
 
-    # 4. 输入账号
+    # 4. 输入账号 - 使用JavaScript直接设置值可能更可靠
     print('Trying to input email...')
+    # 先点击激活输入框
     ActionChains(driver)\
         .move_to_element_with_offset(screen, 280, -80)\
         .click()\
+        .perform()
+    sleep(1)
+    # 清除并输入
+    ActionChains(driver)\
+        .key_down('ctrl')\
+        .key_down('a')\
+        .key_up('a')\
+        .key_up('ctrl')\
+        .perform()
+    sleep(0.5)
+    ActionChains(driver)\
         .send_keys(email)\
         .perform()
     sleep(2)
@@ -78,6 +89,16 @@ for i in range(acccounts):
     ActionChains(driver)\
         .move_to_element_with_offset(screen, 280, -20)\
         .click()\
+        .perform()
+    sleep(1)
+    ActionChains(driver)\
+        .key_down('ctrl')\
+        .key_down('a')\
+        .key_up('a')\
+        .key_up('ctrl')\
+        .perform()
+    sleep(0.5)
+    ActionChains(driver)\
         .send_keys(passwd)\
         .perform()
     sleep(2)
@@ -94,7 +115,7 @@ for i in range(acccounts):
         .click()\
         .perform()
     print('Login button clicked')
-    sleep(35)  # 等待游戏加载完成
+    sleep(40)  # 等待游戏加载完成
     print('Login success')
 
     # 7. 领取月卡

--- a/login.py
+++ b/login.py
@@ -4,7 +4,6 @@ from time import sleep
 from selenium import webdriver
 from selenium.webdriver import ActionChains
 from selenium.webdriver.common.by import By
-# 新增：等待页面加载的依赖
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 
@@ -15,10 +14,9 @@ for i in range(acccounts):
     passwd = sys.argv[1+i+acccounts]
     print('----------------------------')
 
-    #1.open browser 【核心修复：添加反雀魂风控参数，GitHub服务器必备】
+    # 1. 打开浏览器（反风控配置，必须保留）
     options = webdriver.ChromeOptions()
     options.add_argument("--headless=new")
-    # 👇 以下是新增的关键配置，绕过自动化检测，让游戏正常加载
     options.add_argument("--disable-blink-features=AutomationControlled")
     options.add_argument("--no-sandbox")
     options.add_argument("--disable-dev-shm-usage")
@@ -29,42 +27,42 @@ for i in range(acccounts):
     driver.set_window_size(1000, 720)
     driver.get("https://game.maj-soul.net/1/")
     print(f'Account {i+1} loading game...')
-    sleep(10) # 缩短预加载时间，配合显式等待更高效
+    sleep(10)
 
-    #2.input email 【核心修复：等待元素加载，替换为更稳定的canvas定位】
+    # 2. 等待游戏画布加载（修复找不到元素）
     try:
-        # 等待canvas元素加载完成（最长等20秒），解决找不到layaCanvas的问题
         screen = WebDriverWait(driver, 20).until(
             EC.presence_of_element_located((By.TAG_NAME, "canvas"))
         )
-    except Exception as e:
-        # 失败截图，方便排查问题
-        driver.save_screenshot(f"account_{i+1}_error.png")
-        print(f"❌ 账号{i+1} 游戏界面加载失败")
+    except:
+        driver.save_screenshot(f"error_{i+1}.png")
         driver.quit()
-        raise e
+        raise
 
+    # 3. 点击账号输入框 + 直接输入（核心修复：删除了错误的find_element）
     ActionChains(driver)\
         .move_to_element_with_offset(screen, 250, -100)\
         .click()\
         .perform()
-    driver.find_element(By.NAME, 'input').send_keys(email)
+    sleep(1)
+    driver.send_keys(email)  # 直接模拟键盘输入，不需要找input元素
     print('Input email successfully')
 
-    #3.input password
+    # 4. 点击密码输入框 + 直接输入（核心修复：删除了错误的find_element）
     ActionChains(driver)\
         .move_to_element_with_offset(screen, 250, -50)\
         .click()\
         .perform()
-    driver.find_element(By.NAME, 'input_password').send_keys(passwd)
+    sleep(1)
+    driver.send_keys(passwd)
     print('Input password successfully')
 
-    #4.login
+    # 5. 点击登录
     ActionChains(driver)\
         .move_to_element_with_offset(screen, 250, 50)\
         .click()\
         .perform()
     print('Entering game...')
-    sleep(20) #loading...
+    sleep(20)
     print('Login success')
     driver.quit()

--- a/login.py
+++ b/login.py
@@ -4,6 +4,7 @@ from time import sleep
 from selenium import webdriver
 from selenium.webdriver import ActionChains
 from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 
@@ -40,9 +41,8 @@ for i in range(acccounts):
         raise
     
     # 3. 等待游戏资源加载完成（出现登录界面）
-    # 等待更长时间，直到登录界面完全加载
-    max_wait = 90  # 最多等待90秒
-    wait_interval = 10  # 每10秒检查一次
+    max_wait = 90
+    wait_interval = 10
     waited = 0
     
     print('Waiting for game to fully load...')
@@ -52,30 +52,26 @@ for i in range(acccounts):
         driver.save_screenshot(f"loading_check_{i+1}_{waited}.png")
         print(f'  Checked at {waited}s')
         
-        # 等待60秒后尝试输入
         if waited >= 60:
             break
     
     print(f'Waited {waited}s for game load')
     
-    # 保存登录界面截图
     driver.save_screenshot(f"login_screen_{i+1}.png")
     print('Login screen captured')
 
-    # 4. 输入账号 - 使用JavaScript直接设置值可能更可靠
+    # 4. 输入账号
     print('Trying to input email...')
-    # 先点击激活输入框
     ActionChains(driver)\
         .move_to_element_with_offset(screen, 280, -80)\
         .click()\
         .perform()
     sleep(1)
-    # 清除并输入
+    # 使用 Keys 来全选
     ActionChains(driver)\
-        .key_down('ctrl')\
-        .key_down('a')\
-        .key_up('a')\
-        .key_up('ctrl')\
+        .key_down(Keys.CONTROL)\
+        .send_keys('a')\
+        .key_up(Keys.CONTROL)\
         .perform()
     sleep(0.5)
     ActionChains(driver)\
@@ -92,10 +88,9 @@ for i in range(acccounts):
         .perform()
     sleep(1)
     ActionChains(driver)\
-        .key_down('ctrl')\
-        .key_down('a')\
-        .key_up('a')\
-        .key_up('ctrl')\
+        .key_down(Keys.CONTROL)\
+        .send_keys('a')\
+        .key_up(Keys.CONTROL)\
         .perform()
     sleep(0.5)
     ActionChains(driver)\
@@ -104,7 +99,6 @@ for i in range(acccounts):
     sleep(2)
     print('Password input attempted')
 
-    # 保存输入后截图
     driver.save_screenshot(f"after_input_{i+1}.png")
     print('Input screen captured')
 
@@ -115,21 +109,19 @@ for i in range(acccounts):
         .click()\
         .perform()
     print('Login button clicked')
-    sleep(40)  # 等待游戏加载完成
+    sleep(40)
     print('Login success')
 
     # 7. 领取月卡
     print('Attempting to claim monthly card...')
     sleep(5)
     
-    # 第一次点击
     ActionChains(driver)\
         .move_to_element_with_offset(screen, 0, 50)\
         .click()\
         .perform()
     sleep(2)
     
-    # 第二次点击
     ActionChains(driver)\
         .move_to_element_with_offset(screen, 0, 50)\
         .click()\
@@ -138,7 +130,6 @@ for i in range(acccounts):
     
     print('Monthly card claim attempt completed')
     
-    # 保存结果截图
     driver.save_screenshot(f"result_{i+1}.png")
     print(f'Screenshot saved as result_{i+1}.png')
     

--- a/login.py
+++ b/login.py
@@ -63,12 +63,12 @@ for i in range(acccounts):
         .click()\
         .perform()
     print('Entering game...')
-    sleep(20)
+    sleep(30)  # 增加等待时间，等待游戏加载完成
     print('Login success')
 
     # 6. 领取月卡 - 月卡弹窗会在登录后自动显示在中间，直接点击即可
     print('Attempting to claim monthly card...')
-    sleep(3)  # 等待月卡弹窗出现
+    sleep(5)  # 等待月卡弹窗出现
     
     # 第一次点击 - 打开月卡弹窗或点击领取
     ActionChains(driver)\

--- a/login.py
+++ b/login.py
@@ -14,21 +14,19 @@ for i in range(acccounts):
     passwd = sys.argv[1+i+acccounts]
     print('----------------------------')
 
-    # 1. 浏览器配置（反风控，GitHub必备）
     options = webdriver.ChromeOptions()
     options.add_argument("--headless=new")
     options.add_argument("--disable-blink-features=AutomationControlled")
     options.add_argument("--no-sandbox")
     options.add_argument("--disable-dev-shm-usage")
+    options.add_argument("--window-size=1280,800")
     options.add_experimental_option("excludeSwitches", ["enable-automation"])
     options.add_experimental_option('useAutomationExtension', False)
     
     driver = webdriver.Chrome(options=options)
-    driver.set_window_size(1280, 800)
     driver.get("https://game.maj-soul.net/1/")
     print(f'Account {i+1} loading game...')
     
-    # 2. 等待游戏画布加载
     try:
         screen = WebDriverWait(driver, 60).until(
             EC.presence_of_element_located((By.TAG_NAME, "canvas"))
@@ -39,7 +37,6 @@ for i in range(acccounts):
         driver.quit()
         raise
     
-    # 3. 等待游戏资源加载完成
     print('Waiting for game to fully load...')
     sleep(60)
     print('Game load wait completed')
@@ -47,68 +44,80 @@ for i in range(acccounts):
     driver.save_screenshot(f"login_screen_{i+1}.png")
     print('Login screen captured')
 
-    # 4. 输入账号 - 调整坐标
     print('Trying to input email...')
     ActionChains(driver)\
-        .move_to_element_with_offset(screen, 300, -130)\
+        .move_to_element_with_offset(screen, 750, 180)\
         .click()\
+        .perform()
+    sleep(1)
+    ActionChains(driver)\
         .send_keys(email)\
         .perform()
     sleep(2)
     print('Email input attempted')
 
-    # 5. 输入密码 - 调整坐标
+    driver.save_screenshot(f"after_email_{i+1}.png")
+    print('After email input captured')
+
     print('Trying to input password...')
     ActionChains(driver)\
-        .move_to_element_with_offset(screen, 300, -50)\
+        .move_to_element_with_offset(screen, 750, 240)\
         .click()\
+        .perform()
+    sleep(1)
+    ActionChains(driver)\
         .send_keys(passwd)\
         .perform()
     sleep(2)
     print('Password input attempted')
 
-    driver.save_screenshot(f"after_input_{i+1}.png")
-    print('Input screen captured')
+    driver.save_screenshot(f"after_password_{i+1}.png")
+    print('After password input captured')
 
-    # 6. 点击登录
     print('Clicking login button...')
     ActionChains(driver)\
-        .move_to_element_with_offset(screen, 300, 30)\
+        .move_to_element_with_offset(screen, 750, 340)\
         .click()\
         .perform()
     print('Login button clicked')
-    sleep(5)
+    sleep(15)
     
-    # 7. 关闭服务器选择弹窗（如果出现）
-    driver.save_screenshot(f"before_close_{i+1}.png")
-    print('Checking for server selection dialog...')
-    
-    # 点击关闭按钮位置（弹窗右上角）
-    ActionChains(driver)\
-        .move_to_element_with_offset(screen, 300, -200)\
-        .click()\
-        .perform()
-    sleep(2)
-    
-    # 等待进入游戏
-    sleep(35)
-    print('Login success')
+    driver.save_screenshot(f"after_login_click_{i+1}.png")
+    print('After login click captured')
 
-    # 8. 领取月卡
-    print('Attempting to claim monthly card...')
+    print('Waiting for login process...')
+    sleep(45)
+    
+    driver.save_screenshot(f"after_login_wait_{i+1}.png")
+    print('After login wait captured')
+
+    print('Checking for server selection...')
     sleep(5)
     
     ActionChains(driver)\
+        .move_to_element_with_offset(screen, 750, 100)\
+        .click()\
+        .perform()
+    sleep(5)
+
+    driver.save_screenshot(f"after_server_select_{i+1}.png")
+    print('After server select captured')
+
+    print('Waiting for game entry...')
+    sleep(30)
+
+    print('Attempting to claim monthly card...')
+    ActionChains(driver)\
         .move_to_element_with_offset(screen, 0, 50)\
         .click()\
         .perform()
-    sleep(2)
+    sleep(3)
     
     ActionChains(driver)\
         .move_to_element_with_offset(screen, 0, 50)\
         .click()\
         .perform()
-    sleep(2)
+    sleep(3)
     
     print('Monthly card claim attempt completed')
     

--- a/login.py
+++ b/login.py
@@ -14,7 +14,7 @@ for i in range(acccounts):
     passwd = sys.argv[1+i+acccounts]
     print('----------------------------')
 
-    # 1. 浏览器配置（反风控，GitHub必备）
+    # 1. 浏览器配置（反风控）
     options = webdriver.ChromeOptions()
     options.add_argument("--headless=new")
     options.add_argument("--disable-blink-features=AutomationControlled")
@@ -65,4 +65,29 @@ for i in range(acccounts):
     print('Entering game...')
     sleep(20)
     print('Login success')
+
+    # 6. 领取月卡 - 月卡弹窗会在登录后自动显示在中间，直接点击即可
+    print('Attempting to claim monthly card...')
+    sleep(3)  # 等待月卡弹窗出现
+    
+    # 第一次点击 - 打开月卡弹窗或点击领取
+    ActionChains(driver)\
+        .move_to_element_with_offset(screen, 0, 50)\
+        .click()\
+        .perform()
+    sleep(2)
+    
+    # 第二次点击 - 确认领取或关闭弹窗
+    ActionChains(driver)\
+        .move_to_element_with_offset(screen, 0, 50)\
+        .click()\
+        .perform()
+    sleep(2)
+    
+    print('Monthly card claim attempt completed')
+    
+    # 保存截图以便调试
+    driver.save_screenshot(f"result_{i+1}.png")
+    print(f'Screenshot saved as result_{i+1}.png')
+    
     driver.quit()

--- a/login.py
+++ b/login.py
@@ -24,28 +24,46 @@ for i in range(acccounts):
     options.add_experimental_option('useAutomationExtension', False)
     
     driver = webdriver.Chrome(options=options)
-    driver.set_window_size(1280, 800)  # 增大窗口尺寸
+    driver.set_window_size(1280, 800)
     driver.get("https://game.maj-soul.net/1/")
     print(f'Account {i+1} loading game...')
-    sleep(15)  # 增加初始加载等待时间
-
+    
     # 2. 等待游戏画布加载
     try:
-        screen = WebDriverWait(driver, 20).until(
+        screen = WebDriverWait(driver, 60).until(
             EC.presence_of_element_located((By.TAG_NAME, "canvas"))
         )
         print(f'Canvas found, size: {screen.size}')
     except:
-        driver.save_screenshot(f"error_{i+1}.png")
+        driver.save_screenshot(f"error_canvas_{i+1}.png")
         driver.quit()
         raise
-
+    
+    # 3. 等待游戏资源加载完成（出现登录界面）
+    # 通过多次截图检查来判断是否加载完成
+    max_wait = 60  # 最多等待60秒
+    wait_interval = 5  # 每5秒检查一次
+    waited = 0
+    
+    print('Waiting for game to fully load...')
+    while waited < max_wait:
+        sleep(wait_interval)
+        waited += wait_interval
+        driver.save_screenshot(f"loading_check_{i+1}_{waited}.png")
+        print(f'  Checked at {waited}s')
+        
+        # 检查是否已经出现登录输入框（通过像素判断）
+        # 这里简化处理：等待足够长时间
+        if waited >= 30:  # 至少等待30秒
+            break
+    
+    print(f'Waited {waited}s for game load')
+    
     # 保存登录界面截图
     driver.save_screenshot(f"login_screen_{i+1}.png")
     print('Login screen captured')
 
-    # 3. 输入账号
-    # 尝试不同的坐标位置来定位输入框
+    # 4. 输入账号
     print('Trying to input email...')
     ActionChains(driver)\
         .move_to_element_with_offset(screen, 280, -80)\
@@ -55,7 +73,7 @@ for i in range(acccounts):
     sleep(2)
     print('Email input attempted')
 
-    # 4. 输入密码
+    # 5. 输入密码
     print('Trying to input password...')
     ActionChains(driver)\
         .move_to_element_with_offset(screen, 280, -20)\
@@ -69,17 +87,17 @@ for i in range(acccounts):
     driver.save_screenshot(f"after_input_{i+1}.png")
     print('Input screen captured')
 
-    # 5. 点击登录
+    # 6. 点击登录
     print('Clicking login button...')
     ActionChains(driver)\
         .move_to_element_with_offset(screen, 280, 60)\
         .click()\
         .perform()
     print('Login button clicked')
-    sleep(30)  # 等待游戏加载完成
+    sleep(35)  # 等待游戏加载完成
     print('Login success')
 
-    # 6. 领取月卡
+    # 7. 领取月卡
     print('Attempting to claim monthly card...')
     sleep(5)
     

--- a/login.py
+++ b/login.py
@@ -4,7 +4,9 @@ from time import sleep
 from selenium import webdriver
 from selenium.webdriver import ActionChains
 from selenium.webdriver.common.by import By
-
+# 新增：等待页面加载的依赖
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
 
 acccounts = int(len(sys.argv[1:])/2)
 print(f'Config {acccounts} accounts')
@@ -13,17 +15,35 @@ for i in range(acccounts):
     passwd = sys.argv[1+i+acccounts]
     print('----------------------------')
 
-    #1.open browser
+    #1.open browser 【核心修复：添加反雀魂风控参数，GitHub服务器必备】
     options = webdriver.ChromeOptions()
     options.add_argument("--headless=new")
+    # 👇 以下是新增的关键配置，绕过自动化检测，让游戏正常加载
+    options.add_argument("--disable-blink-features=AutomationControlled")
+    options.add_argument("--no-sandbox")
+    options.add_argument("--disable-dev-shm-usage")
+    options.add_experimental_option("excludeSwitches", ["enable-automation"])
+    options.add_experimental_option('useAutomationExtension', False)
+    
     driver = webdriver.Chrome(options=options)
     driver.set_window_size(1000, 720)
     driver.get("https://game.maj-soul.net/1/")
     print(f'Account {i+1} loading game...')
-    sleep(20)
+    sleep(10) # 缩短预加载时间，配合显式等待更高效
 
-    #2.input email
-    screen = driver.find_element(By.ID, 'layaCanvas')
+    #2.input email 【核心修复：等待元素加载，替换为更稳定的canvas定位】
+    try:
+        # 等待canvas元素加载完成（最长等20秒），解决找不到layaCanvas的问题
+        screen = WebDriverWait(driver, 20).until(
+            EC.presence_of_element_located((By.TAG_NAME, "canvas"))
+        )
+    except Exception as e:
+        # 失败截图，方便排查问题
+        driver.save_screenshot(f"account_{i+1}_error.png")
+        print(f"❌ 账号{i+1} 游戏界面加载失败")
+        driver.quit()
+        raise e
+
     ActionChains(driver)\
         .move_to_element_with_offset(screen, 250, -100)\
         .click()\

--- a/login.py
+++ b/login.py
@@ -14,7 +14,7 @@ for i in range(acccounts):
     passwd = sys.argv[1+i+acccounts]
     print('----------------------------')
 
-    # 1. 打开浏览器（反风控配置，必须保留）
+    # 1. 浏览器配置（反风控，GitHub必备）
     options = webdriver.ChromeOptions()
     options.add_argument("--headless=new")
     options.add_argument("--disable-blink-features=AutomationControlled")
@@ -29,7 +29,7 @@ for i in range(acccounts):
     print(f'Account {i+1} loading game...')
     sleep(10)
 
-    # 2. 等待游戏画布加载（修复找不到元素）
+    # 2. 等待游戏画布加载
     try:
         screen = WebDriverWait(driver, 20).until(
             EC.presence_of_element_located((By.TAG_NAME, "canvas"))
@@ -39,22 +39,22 @@ for i in range(acccounts):
         driver.quit()
         raise
 
-    # 3. 点击账号输入框 + 直接输入（核心修复：删除了错误的find_element）
+    # 3. 输入账号（修复：正确的Canvas输入方式）
     ActionChains(driver)\
         .move_to_element_with_offset(screen, 250, -100)\
         .click()\
+        .send_keys(email)\
         .perform()
     sleep(1)
-    driver.send_keys(email)  # 直接模拟键盘输入，不需要找input元素
     print('Input email successfully')
 
-    # 4. 点击密码输入框 + 直接输入（核心修复：删除了错误的find_element）
+    # 4. 输入密码（修复：正确的Canvas输入方式）
     ActionChains(driver)\
         .move_to_element_with_offset(screen, 250, -50)\
         .click()\
+        .send_keys(passwd)\
         .perform()
     sleep(1)
-    driver.send_keys(passwd)
     print('Input password successfully')
 
     # 5. 点击登录


### PR DESCRIPTION
## 问题描述
因为猫粮改了渲染逻辑，原代码在 GitHub Action 中运行会出现以下致命错误：
1. `NoSuchElementException: Unable to locate element: [id="layaCanvas"]`
2. `NoSuchElementException: Unable to locate element: [name="input"]`
3. `AttributeError: 'WebDriver' object has no attribute 'send_keys'`

## 修复内容
1. **适配新版雀魂渲染逻辑**：雀魂网页端现在是纯 Canvas 渲染，移除了 DOM 中的 `layaCanvas` 和 `input` 元素，改用 `WebDriverWait` 等待 `canvas` 标签加载
2. **修复 Canvas 输入逻辑**：Canvas 游戏无法直接用 `find_element` 定位输入框，改用 `ActionChains` 链式点击+输入
3. **添加反检测配置**：给 Chrome 添加了自动化特征隐藏参数，绕过雀魂的风控检测
4. **优化等待逻辑**：用显式等待替代固定 `sleep`，提高稳定性

## 验证结果
修改后的代码已在 GitHub Action 中测试成功，运行日志显示：
- `Input email successfully`
- `Input password successfully`
- `Login success`
可以正常自动登录。
第二天脚本确实运行成功了， 但是月卡好像需要点一下才能领。此处还要优化。

感谢作者的仓库！这个小修复希望能帮到更多人~
<img width="1297" height="609" alt="image" src="https://github.com/user-attachments/assets/84ce8b22-4f5d-475a-adee-bfdb47ee4cab" />
